### PR TITLE
Removes hardcoded values, replaces token property with api_token

### DIFF
--- a/OmniFocus2Todoist.py
+++ b/OmniFocus2Todoist.py
@@ -47,9 +47,9 @@ for label in labels:
 # label_id from the dicts created above.
 
 api = TodoistAPI()
-response = api.login('craig.martell@gmail.com', 'j84#EYz76IJA')
+response = api.login(username,password)
 user_info = response.json()
-user_api_token = user_info['token']
+user_api_token = user_info['api_token']
 
 file="./OmniFocus.csv"
 


### PR DESCRIPTION
Currently, there are hardcoded values for user and password where the API library is used. This commit replaces the hardcoded values by reusing `username` and `password` instead.

Currently, the `user_api_token` variable is set with an erroneous key of `token`. This commit replaces `token` with `api_token`. 